### PR TITLE
Compute BMSSP recursion level dynamically

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ The algorithm is based on the bounded multi-source shortest path (BMSSP) procedu
 Key parameters in the algorithm:
 - k = log^(1/3)(n)
 - t = log^(2/3)(n)
+- level = ceil(ln(n) / t)
 
 ## License
 

--- a/src/algorithm/fast_sssp.rs
+++ b/src/algorithm/fast_sssp.rs
@@ -486,6 +486,13 @@ where
             let log_n = (n as f64).ln();
             let k = (log_n.powf(1.0/3.0)).ceil() as usize;
             let t = (log_n.powf(2.0/3.0)).ceil() as usize;
+
+            // Level determines the depth of the BMSSP recursion.  It is the
+            // ceiling of ln(n) divided by t as suggested in the paper.
+            let mut level = ((n as f64).ln() / (t as f64)).ceil() as usize;
+            if level < 1 {
+                level = 1;
+            }
             
             println!("Running BMSSP with parameters k={}, t={}", k, t);
             
@@ -500,12 +507,12 @@ where
             distances[working_source] = W::zero();
             predecessors[working_source] = Some(working_source);
             
-            // Execute BMSSP
+            // Execute BMSSP starting from the computed top level
             let _bmssp_result = bmssp.execute(
-                &working_graph, 
-                1, // Top level
-                W::max_value(), 
-                &[working_source], 
+                &working_graph,
+                level,
+                W::max_value(),
+                &[working_source],
                 &mut distances,
                 &mut predecessors
             )?;


### PR DESCRIPTION
## Summary
- calculate the top level for BMSSP from the graph size
- use this level when executing BMSSP
- document the new level parameter in README

## Testing
- `cargo fmt` *(fails: component not installed)*
- `cargo test` *(fails: network access required)*

------
https://chatgpt.com/codex/tasks/task_e_685957e7034083339540c3b1b3f9f42e