### PR TITLE
Fix road network example compile

### DIFF
--- a/examples/road_network_benchmark.rs
+++ b/examples/road_network_benchmark.rs
@@ -1,7 +1,7 @@
 use fast_sssp::algorithm::dijkstra::Dijkstra;
 use fast_sssp::algorithm::fast_sssp::FastSSSP;
 use fast_sssp::algorithm::traits::ShortestPathAlgorithm;
-use fast_sssp::graph::{DirectedGraph, MutableGraph};
+use fast_sssp::graph::{DirectedGraph, MutableGraph, Graph};
 use ordered_float::OrderedFloat;
 use std::env;
 use std::fs::File;


### PR DESCRIPTION
## Summary
- fix `road_network_benchmark` example compile error by importing `Graph`

## Testing
- `cargo run --release --example road_network_benchmark sample.gr`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6859d225e8008333a0c94c7b7ad3bf9b