### PR TITLE
Use min for new bound

### DIFF
--- a/src/algorithm/bmssp.rs
+++ b/src/algorithm/bmssp.rs
@@ -200,7 +200,10 @@ where
         let result_vec = result_vertices.into_iter().collect::<Vec<_>>();
         
         Ok(BMSSPResult {
-            new_bound: if block_list.is_empty() { bound } else { prev_bound },
+            // Return the smallest bound encountered. If no vertices were
+            // processed (`block_list` empty), `prev_bound` remains equal to
+            // `bound`, so the minimum is the original bound.
+            new_bound: std::cmp::min(bound, prev_bound),
             vertices: result_vec,
         })
     }


### PR DESCRIPTION
## Summary
- simplify new-bound computation using `std::cmp::min`
- document new-bound logic in `BMSSP::execute`

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68a24b1c0f3c8333ab32f4f35eec90b8